### PR TITLE
Changing Notation in README.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -2,7 +2,7 @@
 
 The Fairly Fast Fetcher. Requests a bunch of URLs provided on stdin fairly quickly.
 
-The main idea is to launch a new request every `n` milliseconds, without waiting
+The main idea is to launch a new request every $n$ milliseconds, without waiting
 for the last request to finish first. This makes for consistently fast fetching,
 but can be hard on system resources (e.g. you might run out of file descriptors).
 The advantage though, is that hitting a bunch of very slow URLs or URLs that


### PR DESCRIPTION
`n` to $n$ in order to better match general standards (using latex).